### PR TITLE
Jupyter hub install

### DIFF
--- a/docs/workspace/jupyter/hub/config.rst
+++ b/docs/workspace/jupyter/hub/config.rst
@@ -99,8 +99,8 @@ but the upstream Apache web server.
        SSLEngine On
        SSLCertificateFile /etc/ssl/certs/jupyter.cusy.io_cert.pem
        SSLCertificateKeyFile /etc/ssl/private/jupyter.cusy.io_sec_key.pem
-       SSLProtocol All -SSLv2 -SSLv3
-       SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
+       # for an up-to-date SSL configuration see e.g.
+       # https://ssl-config.mozilla.org/
 
        # Use RewriteEngine to handle websocket connection upgrades
        RewriteEngine On

--- a/docs/workspace/jupyter/hub/config.rst
+++ b/docs/workspace/jupyter/hub/config.rst
@@ -21,9 +21,9 @@ System service for JupyterHub
 
    .. code-block:: console
 
-    $ cd ~/jupyterhub
+    $ cd ~/jupyter-tutorial
     $ pipenv --venv
-    /srv/jupyter/.local/share/virtualenvs/jupyterhub-aFv4x91W
+    /srv/jupyter/.local/share/virtualenvs/jupyter-tutorial-aFv4x91W
 
 #. Configuring ``/etc/systemd/system/jupyterhub.service`` and
    ``/lib/systemd/system/jupyterhub.service``:
@@ -35,8 +35,8 @@ System service for JupyterHub
 
     [Service]
     User=root
-    Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/srv/jupyter/.local/share/virtualenvs/jupyterhub-aFv4x91W/bin"
-    ExecStart=/srv/jupyter/.local/share/virtualenvs/jupyterhub-aFv4x91W/bin/jupyterhub -f /srv/jupyter/jupyterhub/jupyterhub_config.py
+    Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/srv/jupyter/.local/share/virtualenvs/jupyter-tutorial-aFv4x91W/bin"
+    ExecStart=/srv/jupyter/.local/share/virtualenvs/jupyterhub-aFv4x91W/bin/jupyterhub -f /srv/jupyter/jupyter-tutorial/jupyterhub_config.py
 
     [Install]
     WantedBy=multi-user.target

--- a/docs/workspace/jupyter/hub/config.rst
+++ b/docs/workspace/jupyter/hub/config.rst
@@ -25,8 +25,13 @@ System service for JupyterHub
     $ pipenv --venv
     /srv/jupyter/.local/share/virtualenvs/jupyter-tutorial-aFv4x91W
 
-#. Configuring ``/etc/systemd/system/jupyterhub.service`` and
-   ``/lib/systemd/system/jupyterhub.service``:
+#. Add a new systemd unit file ``/etc/systemd/system/jupyterhub.service`` with this command:
+
+   .. code-block:: console
+
+      # systemctl edit --force --full jupyterhub.service
+
+   Insert your according Python virtual environment.
 
    .. code-block:: ini
 
@@ -36,18 +41,10 @@ System service for JupyterHub
     [Service]
     User=root
     Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/srv/jupyter/.local/share/virtualenvs/jupyter-tutorial-aFv4x91W/bin"
-    ExecStart=/srv/jupyter/.local/share/virtualenvs/jupyterhub-aFv4x91W/bin/jupyterhub -f /srv/jupyter/jupyter-tutorial/jupyterhub_config.py
+    ExecStart=/srv/jupyter/.local/share/virtualenvs/jupyter-tutorial-aFv4x91W/bin/jupyterhub -f /srv/jupyter/jupyter-tutorial/jupyterhub_config.py
 
     [Install]
     WantedBy=multi-user.target
-
-#. Loading the configuration
-
-   with:
-
-   .. code-block:: console
-
-    # systemctl daemon-reload
 
 #. The JupyterHub can be managed with:
 
@@ -60,8 +57,8 @@ System service for JupyterHub
 
    .. code-block:: console
 
-    $ systemctl enable jupyterhub.service
-    systemctl enable jupyterhub.service
+    # systemctl enable jupyterhub.service
+    Created symlink /etc/systemd/system/multi-user.target.wants/jupyterhub.service → /etc/systemd/system/jupyterhub.service.
 
 TLS encryption
 --------------

--- a/docs/workspace/jupyter/hub/install.rst
+++ b/docs/workspace/jupyter/hub/install.rst
@@ -75,7 +75,7 @@ Installation
 
    ``10.x`` indicates the major version of ``nodejs``.
 
-#. Installi the ``npm`` packages:
+#. Install the ``npm`` packages:
 
    .. code-block:: console
 

--- a/docs/workspace/jupyter/hub/install.rst
+++ b/docs/workspace/jupyter/hub/install.rst
@@ -86,13 +86,13 @@ Installation
 
    .. code-block:: console
 
-    $ npm install
+    # npm install
 
 #. Install the HTTP-Proxy:
 
    .. code-block:: console
 
-    $ $ npm install -g configurable-http-proxy
+    # npm install -g configurable-http-proxy
     /usr/local/bin/configurable-http-proxy -> /usr/local/lib/node_modules/configurable-http-proxy/bin/configurable-http-proxy
     + configurable-http-proxy@4.1.0
     added 47 packages from 62 contributors in 6.208s

--- a/docs/workspace/jupyter/hub/install.rst
+++ b/docs/workspace/jupyter/hub/install.rst
@@ -52,6 +52,13 @@ Installation
 
     $  source ~/.profile
 
+#. Edit the ``Pipfile`` in the unpacked archive and enter your current Python version in this section:
+
+  .. code-block:: console
+
+    [requires]
+    python_version = ""
+
 #. Create a virtual environment and install JupyterHub:
 
    .. code-block:: console


### PR DESCRIPTION
Worked on Jupyter Hub Installation. The directory ``/srv/jupyter/jupyterhub`` is not created in the tutorial so I corrected it to ``/srv/juypter/jupyter-tutorial`` - I am wondering if it is meant to be like that or not.